### PR TITLE
use owned parameters for aep in power_source.simulate_financials over…

### DIFF
--- a/hopp/simulation/technologies/financial/custom_financial_model.py
+++ b/hopp/simulation/technologies/financial/custom_financial_model.py
@@ -346,7 +346,6 @@ class CustomFinancialModel():
             'batt_replacement_schedule_percent': self.BatterySystem.batt_replacement_schedule_percent,
         }
 
-
     @property
     def annual_energy(self) -> float:
         return self.value('annual_energy_pre_curtailment_ac')

--- a/hopp/simulation/technologies/power_source.py
+++ b/hopp/simulation/technologies/power_source.py
@@ -10,7 +10,6 @@ from hopp.simulation.technologies.dispatch.power_sources.power_source_dispatch i
 from hopp.tools.utils import array_not_scalar, equal
 from hopp.utilities.log import hybrid_logger as logger
 
-
 class PowerSource:
     """
     Abstract class for a renewable energy power plant simulation.
@@ -300,9 +299,10 @@ class PowerSource:
                 raise RuntimeError(f"simulate_financials error: generation profile of len {self.site.n_timesteps} required")
 
         if len(self._financial_model.value('gen')) == self.site.n_timesteps:
+            #TODO is this correct? It seems like gen should not be multiplied by project life
             self._financial_model.value('gen', self._financial_model.value('gen') * project_life)
         self._financial_model.value('system_pre_curtailment_kwac', self._financial_model.value('gen'))
-        self._financial_model.value('annual_energy_pre_curtailment_ac', self._system_model.value("annual_energy"))
+        self._financial_model.value('annual_energy_pre_curtailment_ac', self.value("annual_energy_kwh"))
         # TODO: Should we use the nominal capacity function here?
         self.gen_max_feasible = self.calc_gen_max_feasible_kwh(interconnect_kw)
         self.capacity_credit_percent = self.calc_capacity_credit_percent(interconnect_kw)
@@ -321,7 +321,6 @@ class PowerSource:
         self.setup_performance_model()
         self.simulate_power(project_life, lifetime_sim)
         self.simulate_financials(interconnect_kw, project_life)
-        
         logger.info(f"{self.name} simulation executed with AEP {self.annual_energy_kwh}")
 
     #

--- a/tests/hopp/test_custom_financial.py
+++ b/tests/hopp/test_custom_financial.py
@@ -126,6 +126,7 @@ def test_detailed_pv(site):
     assert aeps.hybrid == approx(annual_energy_expected, 1e-3)
     assert npvs.pv == approx(npv_expected, 1e-3)
     assert npvs.hybrid == approx(npv_expected, 1e-3)
+    assert npvs.hybrid == approx(npvs.pv, 1e-10)
 
 
 def test_hybrid_simple_pv_with_wind(site):


### PR DESCRIPTION
This pull request changes the `power_source.py` class `PowerSource` to use its own `annual_energy_kwh` parameter in `simulate_financials` rather than directly using the `annual_energy` parameter from _system_model. This allows override of the parameter in inheriting classes as necessary (e.g. when using the MHK model from SAM that only takes data on 3-hour intervals).

The primary change is line 305 in `power_source.py`