### PR TITLE
update test_dispatch to use local resource files and not call the database APIs

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -15,7 +15,7 @@ lxml
 matplotlib
 multiprocessing-on-dill
 nevergrad
-numpy
+numpy<2.0
 numpy-financial
 optuna
 pandas>=2.0.3

--- a/tests/hopp/test_dispatch.py
+++ b/tests/hopp/test_dispatch.py
@@ -998,8 +998,7 @@ def test_hybrid_dispatch_baseload_heuristic_and_analysis(site):
 
     desired_schedule = 8760*[20]
 
-    desired_schedule_site = SiteInfo(flatirons_site,
-                                     desired_schedule=desired_schedule)
+    desired_schedule_site = create_default_site_info(desired_schedule=desired_schedule)
     wind_solar_battery = {key: technologies[key] for key in ('pv', 'wind', 'battery')}
 
     dispatch_options = {'battery_dispatch': 'load_following_heuristic',


### PR DESCRIPTION
I believe we have moved to not using API calls in the tests so that the automated testing workflow can be simplified/not require a specific API key and email. I have updated a test in `test_dispatch.py` to use the solar and wind input files available in the default site test fixture.